### PR TITLE
Expand NewsAPI Middlewares

### DIFF
--- a/controllers/newsapiController.js
+++ b/controllers/newsapiController.js
@@ -52,6 +52,24 @@ exports.postTopHeadlines = catchAsync(async (req, res, next) => {
 });
 
 // EVERYTHING
+// -- GET method
+exports.getEverything = catchAsync(async (req, res, next) => {
+  const { apiKey } = sanitize(req.query);
+  const filteredQuery = sanitize(filterObj(req.query, 'apiKey'));
+
+  const newsapi = new NewsAPI(apiKey);
+
+  try {
+    const data = await newsapi.v2.everything(filteredQuery);
+
+    res.status(200).json({
+      ...data,
+    });
+  } catch (error) {
+    return next(new AppError(error.message, 500));
+  }
+});
+
 // -- POST method
 exports.postEverything = catchAsync(async (req, res, next) => {
   const { apiKey } = sanitize(req.body);

--- a/controllers/newsapiController.js
+++ b/controllers/newsapiController.js
@@ -13,7 +13,7 @@ exports.confirmApikey = (req, res, next) => {
   next();
 };
 
-exports.topHeadlines = catchAsync(async (req, res, next) => {
+exports.postTopHeadlines = catchAsync(async (req, res, next) => {
   const { apiKey } = sanitize(req.body);
   const filteredBody = sanitize(filterObj(req.body, 'apiKey'));
 
@@ -30,7 +30,7 @@ exports.topHeadlines = catchAsync(async (req, res, next) => {
   }
 });
 
-exports.everything = catchAsync(async (req, res, next) => {
+exports.postEverything = catchAsync(async (req, res, next) => {
   const { apiKey } = sanitize(req.body);
   const filteredBody = sanitize(filterObj(req.body, 'apiKey'));
 
@@ -47,7 +47,7 @@ exports.everything = catchAsync(async (req, res, next) => {
   }
 });
 
-exports.sources = catchAsync(async (req, res, next) => {
+exports.postSources = catchAsync(async (req, res, next) => {
   const { apiKey } = sanitize(req.body);
   const filteredBody = sanitize(filterObj(req.body, 'apiKey'));
 

--- a/controllers/newsapiController.js
+++ b/controllers/newsapiController.js
@@ -14,6 +14,26 @@ exports.confirmApikey = (req, res, next) => {
   next();
 };
 
+// TOP-HEADLINES
+// -- GET method
+exports.getTopHeadlines = catchAsync(async (req, res, next) => {
+  const { apiKey } = sanitize(req.query);
+  const filteredQuery = sanitize(filterObj(req.query, 'apiKey'));
+
+  const newsapi = new NewsAPI(apiKey);
+
+  try {
+    const data = await newsapi.v2.topHeadlines(filteredQuery);
+
+    res.status(200).json({
+      ...data,
+    });
+  } catch (error) {
+    return next(new AppError(error.message, 500));
+  }
+});
+
+// -- POST method
 exports.postTopHeadlines = catchAsync(async (req, res, next) => {
   const { apiKey } = sanitize(req.body);
   const filteredBody = sanitize(filterObj(req.body, 'apiKey'));
@@ -31,6 +51,8 @@ exports.postTopHeadlines = catchAsync(async (req, res, next) => {
   }
 });
 
+// EVERYTHING
+// -- POST method
 exports.postEverything = catchAsync(async (req, res, next) => {
   const { apiKey } = sanitize(req.body);
   const filteredBody = sanitize(filterObj(req.body, 'apiKey'));
@@ -48,6 +70,8 @@ exports.postEverything = catchAsync(async (req, res, next) => {
   }
 });
 
+// SOURCES
+// -- POST method
 exports.postSources = catchAsync(async (req, res, next) => {
   const { apiKey } = sanitize(req.body);
   const filteredBody = sanitize(filterObj(req.body, 'apiKey'));

--- a/controllers/newsapiController.js
+++ b/controllers/newsapiController.js
@@ -2,7 +2,8 @@ const NewsAPI = require('newsapi');
 const { AppError, catchAsync, filterObj, sanitize } = require('../utils');
 
 exports.confirmApikey = (req, res, next) => {
-  const { apiKey } = sanitize(req.body);
+  const { apiKey } =
+    req.method === 'POST' ? sanitize(req.body) : sanitize(req.query);
 
   if (!apiKey) {
     return next(

--- a/controllers/newsapiController.js
+++ b/controllers/newsapiController.js
@@ -89,6 +89,24 @@ exports.postEverything = catchAsync(async (req, res, next) => {
 });
 
 // SOURCES
+// -- GET method
+exports.getSources = catchAsync(async (req, res, next) => {
+  const { apiKey } = sanitize(req.query);
+  const filteredQuery = sanitize(filterObj(req.query, 'apiKey'));
+
+  const newsapi = new NewsAPI(apiKey);
+
+  try {
+    const data = await newsapi.v2.sources(filteredQuery);
+
+    res.status(200).json({
+      ...data,
+    });
+  } catch (error) {
+    return next(new AppError(error.message, 500));
+  }
+});
+
 // -- POST method
 exports.postSources = catchAsync(async (req, res, next) => {
   const { apiKey } = sanitize(req.body);

--- a/routes/newsapiRoutes.js
+++ b/routes/newsapiRoutes.js
@@ -15,6 +15,7 @@ router
 
 router
   .route('/sources')
+  .get(newsapiController.confirmApikey, newsapiController.getSources)
   .post(newsapiController.confirmApikey, newsapiController.postSources);
 
 module.exports = router;

--- a/routes/newsapiRoutes.js
+++ b/routes/newsapiRoutes.js
@@ -10,6 +10,7 @@ router
 
 router
   .route('/everything')
+  .get(newsapiController.confirmApikey, newsapiController.getEverything)
   .post(newsapiController.confirmApikey, newsapiController.postEverything);
 
 router

--- a/routes/newsapiRoutes.js
+++ b/routes/newsapiRoutes.js
@@ -5,6 +5,7 @@ const router = express.Router();
 
 router
   .route('/top-headlines')
+  .get(newsapiController.confirmApikey, newsapiController.getTopHeadlines)
   .post(newsapiController.confirmApikey, newsapiController.postTopHeadlines);
 
 router

--- a/routes/newsapiRoutes.js
+++ b/routes/newsapiRoutes.js
@@ -3,22 +3,16 @@ const { newsapiController } = require('../controllers');
 
 const router = express.Router();
 
-router.post(
-  '/top-headlines',
-  newsapiController.confirmApikey,
-  newsapiController.topHeadlines
-);
+router
+  .route('/top-headlines')
+  .post(newsapiController.confirmApikey, newsapiController.postTopHeadlines);
 
-router.post(
-  '/everything',
-  newsapiController.confirmApikey,
-  newsapiController.everything
-);
+router
+  .route('/everything')
+  .post(newsapiController.confirmApikey, newsapiController.postEverything);
 
-router.post(
-  '/sources',
-  newsapiController.confirmApikey,
-  newsapiController.sources
-);
+router
+  .route('/sources')
+  .post(newsapiController.confirmApikey, newsapiController.postSources);
 
 module.exports = router;


### PR DESCRIPTION
## Changes
1. Changed the names of the POST middlewares to better reflect the type of method.
2. Expanded the routes to include different methods besides the POST method on the same endpoint.
3. Created middlewares and routes for GET methods.

## Purpose
The middlewares and routes needs to be expanded to also handle the GET method.

## Approach
By expanding on the routes and middlewares for the GET method, this allows the developers to have greater options on how to submit their request on either the POST or GET methods.

Closes #15 